### PR TITLE
Add redis db selection

### DIFF
--- a/api/script/redis-manager.ts
+++ b/api/script/redis-manager.ts
@@ -126,10 +126,10 @@ export class RedisManager {
 
       this._setupOpsClientPromise = this._promisifiedOpsClient
         .select(RedisManager.OPS_DB)
-        .then(() => this._promisifiedOpsClient.set("health", "health-ops"));
+        .then(() => this._promisifiedOpsClient.set("health", "health"));
       this._setupMetricsClientPromise = this._promisifiedMetricsClient
         .select(RedisManager.METRICS_DB)
-        .then(() => this._promisifiedMetricsClient.set("health", "health-metrics"));
+        .then(() => this._promisifiedMetricsClient.set("health", "health"));
     } else {
       console.warn("No REDIS_HOST or REDIS_PORT environment variable configured.");
     }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -44,6 +44,8 @@ definitions:
           --env REDIS_HOST="redis-1.internal.codemagic.io" \
           --env REDIS_PORT=6379 \
           --env REDIS_KEY=$REDIS_KEY \
+          --env REDIS_OPS_DB=4 \
+          --env REDIS_METRICS_DB=5 \
           --env LOGGING=true \
           --name code-push-server \
           -p 0.0.0.0:3001:3000 \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -44,8 +44,8 @@ definitions:
           --env REDIS_HOST="redis-1.internal.codemagic.io" \
           --env REDIS_PORT=6379 \
           --env REDIS_KEY=$REDIS_KEY \
-          --env REDIS_OPS_DB=4 \
-          --env REDIS_METRICS_DB=5 \
+          --env REDIS_OPS_DB=2 \
+          --env REDIS_METRICS_DB=1 \
           --env LOGGING=true \
           --name code-push-server \
           -p 0.0.0.0:3001:3000 \


### PR DESCRIPTION
On this PR we introduce new required environment variables `REDIS_OPS_DB` and `REDIS_METRICS_DB` to create a REDIS connection. 

**QA**

I create a deployment with REDIS_OPS_DB=4 and REDIS_METRICS_DB=5 and the result is the expected:

<img width="291" alt="image" src="https://github.com/user-attachments/assets/79c3567e-c6ef-48da-bac9-7b286b189851" />
